### PR TITLE
feat: Synchronize Individual ESCs after playing back startup tune

### DIFF
--- a/js/bluejay_defaults.js
+++ b/js/bluejay_defaults.js
@@ -1,6 +1,26 @@
 'use strict';
 
 var BLUEJAY_DEFAULTS = {
+	'204': { //  201 with STARTUP_MELODY
+		RPM_POWER_SLOPE:            9,
+		MOTOR_DIRECTION:            1,
+		COMMUTATION_TIMING:         4,
+		BEEP_STRENGTH:              40,
+		BEACON_STRENGTH:            80,
+		BEACON_DELAY:               4,
+		DEMAG_COMPENSATION:         2,
+		TEMPERATURE_PROTECTION:     7,
+		BRAKE_ON_STOP:              0,
+		LED_CONTROL:                0,
+
+		STARTUP_POWER_MIN:          51,
+		DITHERING:                  1,
+
+		STARTUP_POWER_MAX:          25,
+		STARTUP_MELODY:             [2,58,4,32,52,66,13,0,69,45,13,0,52,66,13,0,78,39,211,0,69,45,208,25,52,25,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],
+		STARTUP_MELODY_WAIT_MS_MSB: 0,
+		STARTUP_MELODY_WAIT_MS_LSB: 0
+	},
 	'203': { //  201 with STARTUP_MELODY
 		RPM_POWER_SLOPE:            9,
 		MOTOR_DIRECTION:            1,

--- a/js/bluejay_eeprom_layout.js
+++ b/js/bluejay_eeprom_layout.js
@@ -23,7 +23,7 @@ var BLHELI_SILABS_BOOTLOADER_SIZE       = 0x0200
 var BLHELI_SILABS_FLASH_SIZE            = 0x2000
 var BLHELI_SILABS_ADDRESS_SPACE_SIZE    = BLHELI_SILABS_BOOTLOADER_ADDRESS
 
-var BLHELI_LAYOUT_SIZE = 0xF0
+var BLHELI_LAYOUT_SIZE = 0xF2
 var BLHELI_MIN_SUPPORTED_LAYOUT_REVISION = 0x13
 
 var BLHELI_S_MIN_LAYOUT_REVISION = 0x20
@@ -76,7 +76,9 @@ var BLHELI_LAYOUT = {
     MCU:                        {   offset: 0x50, size: 16   },
     NAME:                       {   offset: 0x60, size: 16   },
 
-    STARTUP_MELODY:             {   offset: 0x70, size: 128  }
+    STARTUP_MELODY:             {   offset: 0x70, size: 128  },
+    STARTUP_MELODY_WAIT_MS_MSB: {   offset: 0xF0, size: 1   },
+    STARTUP_MELODY_WAIT_MS_LSB: {   offset: 0xF1, size: 1   }
 };
 
 function blheliModeToString(mode) {


### PR DESCRIPTION
Since we allow each ESC to set it's own startup tune, we can now
automatically configure each of them to wait until all the others have
finished playing their tune.

The support for this is implemented using the new Eeprom variables in
Bluejay:

Eep_Pgm_Tune_Wait_MSB_ms - most significant byte
Eep_Pgm_Tune_Wait_LSB_ms - least significant byte

This should allow us to wait for 65536ms now.

This should typically be enough for most usecases imo. If not, we can
add another byte later on.

Requires: https://github.com/mathiasvr/bluejay/pull/22